### PR TITLE
Add bird_exporter to routereflector

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -14,6 +14,14 @@
 
 # For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
 
+# bird exporter build
+FROM golang AS builder
+RUN go get -d -v github.com/czerwonk/bird_exporter
+WORKDIR /go/src/github.com/czerwonk/bird_exporter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \ 
+    go build -a -installsuffix cgo -o /bird_exporter .
+
+# Main bird image
 FROM ubuntu:16.04
 
 CMD ["/sbin/my_init"]
@@ -45,3 +53,6 @@ ADD /dist/confd-amd64 /confd
 # Copy in our custom configuration files etc. We do this last to speed up
 # builds for developer, as it's thing they're most likely to change.
 COPY node_filesystem /
+
+# Copy the bird_exporter
+COPY --from=builder /bird_exporter /bin/bird_exporter

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -14,6 +14,13 @@
 
 # For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
 
+# bird exporter build
+FROM golang AS builder
+RUN go get -d -v github.com/czerwonk/bird_exporter
+WORKDIR /go/src/github.com/czerwonk/bird_exporter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \ 
+    go build -a -installsuffix cgo -o /bird_exporter .
+
 FROM arm64v8/ubuntu:14.04
 
 CMD ["/sbin/my_init"]
@@ -45,3 +52,6 @@ ADD /dist/confd-arm64 /confd
 # Copy in our custom configuration files etc. We do this last to speed up
 # builds for developer, as it's thing they're most likely to change.
 COPY node_filesystem /
+
+# Copy the bird_exporter
+COPY --from=builder /bird_exporter /bin/bird_exporter

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -15,6 +15,13 @@
 
 # For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
 
+# bird exporter build
+FROM golang AS builder
+RUN go get -d -v github.com/czerwonk/bird_exporter
+WORKDIR /go/src/github.com/czerwonk/bird_exporter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le \ 
+    go build -a -installsuffix cgo -o /bird_exporter .
+
 FROM ppc64le/ubuntu:16.04
 
 RUN apt-get update && \
@@ -50,3 +57,6 @@ ADD /dist/confd-ppc64le /confd
 # Copy in our custom configuration files etc. We do this last to speed up
 # builds for developer, as it's thing they're most likely to change.
 COPY node_filesystem /
+
+# Copy the bird_exporter
+COPY --from=builder /bird_exporter /bin/bird_exporter

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -19,6 +19,13 @@
 # 1) Base image has been changed from ubuntu:14.04 to s390x/ubuntu:16.04
 # 2) Added python3-minimal dependency
 
+# bird exporter build
+FROM golang AS builder
+RUN go get -d -v github.com/czerwonk/bird_exporter
+WORKDIR /go/src/github.com/czerwonk/bird_exporter
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=s390x \ 
+    go build -a -installsuffix cgo -o /bird_exporter .
+
 FROM s390x/ubuntu:16.04
 
 RUN apt-get update && \
@@ -53,3 +60,6 @@ ADD /dist/confd-s390x /confd
 # Copy in our custom configuration files etc. We do this last to speed up
 # builds for developer, as it's thing they're most likely to change.
 COPY node_filesystem /
+
+# Copy the bird_exporter
+COPY --from=builder /bird_exporter /bin/bird_exporter

--- a/node_filesystem/etc/service/bird_exporter/log/run
+++ b/node_filesystem/etc/service/bird_exporter/log/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+LOGDIR=/var/log/calico/bird_exporter
+mkdir -p $LOGDIR
+# Prefix each line with a timestamp
+exec svlogd -tt $LOGDIR

--- a/node_filesystem/etc/service/bird_exporter/run
+++ b/node_filesystem/etc/service/bird_exporter/run
@@ -1,0 +1,5 @@
+#!/bin/sh
+exec 2>&1
+exec bird_exporter -format.new=true \
+                   -bird.socket=/etc/service/bird/bird.ctl \
+                   -bird.socket6=/etc/service/bird6/bird6.ctl


### PR DESCRIPTION
Adds bird exporter to routereflector image.

Adds it as another `runsrv` target.
Uses docker build containers to avoid having to mess much with the `Makefile`

`make` will create a local `calico/routereflector` image that will work.

If testing on localhost without a etcd cluster you can do the following to see metrics:

1. `docker run calico/routereflector` (after doing the `make`)
2. `docker ps` -> copy the id
3. `docker exec -it <id> bash`
4. `cp /etc/bird/bird.conf /config/bird.cfg`
5. `cp /etc/bird/bird6.conf /config/bird6.cfg`
6. `apt update`
7. `apt install curl`
8. `curl localhost:9324/metrics`

And you should see some prometheus metrics about bird: